### PR TITLE
Added show displaced tracks only in num vertex matrix plot.

### DIFF
--- a/configs/config_numvert.yaml
+++ b/configs/config_numvert.yaml
@@ -42,7 +42,9 @@ plots:
     samples:  # specify specific sample here
       path: '/path/to/file'
       colour: mediumblue
+      df_name: tracks_from_jet
     filename: NumVertCompare.png
+    disp_only: False # choose to plot displaced tracks in signal samples only
     max_val: 25
     style:
       <<: *style


### PR DESCRIPTION
One can now choose to plot the only the displaced vertices in the signal jets for the number of unique vertices matrix plot. This helps even out the 2D histogram some more. The option is specified in the config file which I also included.